### PR TITLE
Exit with exit code zero and added requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # calculator.py
 A scientific calculator for your terminal emulator.
 # usage
-If you want to execute it, you need to add perms, e.g. 
-```console
-chmod +x calculator.py
+
 ```
-After adding execution perms, just execute it with
-```console
-./calculator.py
-```
-If you are using Windows, you should only need
-```console
+# Install dependencies
+pip install -r requirements.txt
+
+# Run calculator.py
 python3 calculator.py
 ```
 # functions & constants
-Comes with multiple functions and constants, some packages will need to be installed. <br>
+Comes with multiple functions and constants. <br>
 Examples of some functions:
 ```python
 distance(10, 'in', 'cm') # 25.4 cm
@@ -39,7 +35,7 @@ if you forget what you typed after clearing your screen with the "clear" command
 hist
 ```
 # functions that require packages
-Some functions will require external packages, example of one is scipy
+Some functions use packages that aren't in the standard library, example of one is scipy
 ```python
 z2p(1) # approx. 0.84
 p2z(.84) # approx. 1

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A scientific calculator for your terminal emulator.
 # usage
 
-```
+```console
 # Install dependencies
 pip install -r requirements.txt
 

--- a/calculator.py
+++ b/calculator.py
@@ -466,11 +466,14 @@ if var_args.get('e') != None:
     ui = var_args.get('e')
     fixedString = fixUI(ui)
     if fixedString != None:
-        result = eval(fixedString)
+        try:
+            result = eval(fixedString)
+        except Exception as _e:
+            exit(_e)
         if isNumber(result) and result < sys.float_info.max:
-            exit(f"{result:e}") if result >= 1e18 else exit(f"{result:,}")
+            print(f"{result:e}") if result >= 1e18 else print(f"{result:,}")
         else:
-            exit(result)
+            print(result)
     exit()
 
 while True:
@@ -498,11 +501,14 @@ while True:
                     elif result != None:
                         print(result)
     except KeyboardInterrupt:
-        if exitAttempts >= 1: exit("\nTerminating script ...")
+        if exitAttempts >= 1:
+            print("\nTerminating script ...")
+            exit()
         exitAttempts += 1
         print("\nConfirm exit via ctrl+C or ctrl+D")
     except EOFError:
-        exit("\nTerminating script ...")
+        print("\nTerminating script ...")
+        exit()
     except Exception as _e:
         print(_e)
         #print(sys.exc_info()[-1].tb_lineno, type(_e).__name__) get line of error

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+prompt-toolkit
+statistics
+sympy
+scipy


### PR DESCRIPTION
Exiting with `exit("<message>")` returns a non-zero exit code, which isn't supposed to be returned if there is no errors. Any scripts/programs calling calculator.py will think there was an error due to the exit code not being 0.